### PR TITLE
feat: allow origanization to invite team members

### DIFF
--- a/app/Enums/Role.php
+++ b/app/Enums/Role.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Enums;
+
+enum Role: string
+{
+    case MEMBER = 'member';
+
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+} 

--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -4,23 +4,38 @@ namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Auth\LoginRequest;
+use App\Models\Organization;
+use App\Services\OrganizationService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Session;
 use Inertia\Inertia;
 use Inertia\Response;
 
 class AuthenticatedSessionController extends Controller
 {
+    protected $organizationService;
+
+    public function __construct(OrganizationService $organizationService)
+    {
+        $this->organizationService = $organizationService;
+    }
+
     /**
      * Show the login page.
      */
     public function create(Request $request): Response
     {
+        $organization = $this->organizationService->getOrganizationByJoinToken(
+            Session::get('join_token')
+        );
+        
         return Inertia::render('auth/login', [
             'canResetPassword' => Route::has('password.request'),
             'status' => $request->session()->get('status'),
+            'organization' => $organization,
         ]);
     }
 
@@ -32,6 +47,30 @@ class AuthenticatedSessionController extends Controller
         $request->authenticate();
 
         $request->session()->regenerate();
+
+        $user = $request->user();
+
+        $organization = $this->organizationService->getOrganizationByJoinToken(
+            Session::get('join_token')
+        );
+
+        if ($organization) {
+
+            // If the user is already a member of the organization, redirect back with an error
+            if ($user->organizations->contains($organization->id)) {
+                return redirect()->back()->with('error', 'You are already a member of this organization.');
+            }
+
+            // Join the organization
+            $this->organizationService->attachUserToOrganization($user, $organization);
+            
+            // Clear the join token from the session
+            Session::forget('join_token');
+            
+            return redirect()
+                ->route('dashboard')
+                ->with('success', 'Successfully joined organization.');
+        }
 
         return redirect()->intended(route('dashboard', absolute: false));
     }

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -3,24 +3,39 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
+use App\Models\Organization;
 use App\Models\User;
+use App\Services\OrganizationService;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Session;
 use Illuminate\Validation\Rules;
 use Inertia\Inertia;
 use Inertia\Response;
 
 class RegisteredUserController extends Controller
 {
+    protected $organizationService;
+
+    public function __construct(OrganizationService $organizationService)
+    {
+        $this->organizationService = $organizationService;
+    }
     /**
      * Show the registration page.
      */
     public function create(): Response
     {
-        return Inertia::render('auth/register');
+        $organization = $this->organizationService->getOrganizationByJoinToken(
+            Session::get('join_token')
+        );
+
+        return Inertia::render('auth/register', [
+            'organization' => $organization,
+        ]);
     }
 
     /**
@@ -45,7 +60,29 @@ class RegisteredUserController extends Controller
         event(new Registered($user));
 
         Auth::login($user);
+        
+        $organization = $this->organizationService->getOrganizationByJoinToken(
+            Session::get('join_token')
+        );
 
-        return to_route('dashboard');
+        if ($organization) {
+
+            // If the user is already a member of the organization, redirect back with an error
+            if ($user->organizations->contains($organization->id)) {
+                return redirect()->back()->with('error', 'You are already a member of this organization.');
+            }
+
+            // Join the organization
+            $this->organizationService->attachUserToOrganization($user, $organization);
+            
+            // Clear the join token from the session
+            Session::forget('join_token');
+            
+            return redirect()
+                ->route('dashboard')
+                ->with('success', 'Account created and joined organization successfully.');
+        }
+
+        return redirect()->route('dashboard');
     }
 }

--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Store\Offer;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -16,6 +17,7 @@ class Organization extends Model
         'name',
         'ulid',
         'default_currency',
+        'join_token',
     ];
 
     protected $appends = [
@@ -40,12 +42,15 @@ class Organization extends Model
         
         static::creating(function ($organization) {
             $organization->ulid = Str::ulid();
+            $organization->join_token = hash('sha256', $organization->ulid);
         });
     }
 
     public function users(): BelongsToMany
     {
         return $this->belongsToMany(User::class, 'organization_users')
+            ->using(OrganizationUser::class)
+            ->withPivot('role')
             ->withTimestamps();
     }
 
@@ -56,6 +61,6 @@ class Organization extends Model
 
     public function getInviteLinkAttribute(): string
     {
-        return route('organizations.join', $this->ulid);
+        return route('auth.join', $this->join_token);
     }
 }

--- a/app/Models/OrganizationUser.php
+++ b/app/Models/OrganizationUser.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\Role;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+class OrganizationUser extends Pivot
+{
+    protected $table = 'organization_users';
+
+    protected $fillable = [
+        'role',
+    ];
+
+    protected $casts = [
+        'role' => Role::class,
+    ];
+
+    protected $attributes = [
+        'role' => Role::MEMBER,
+    ];
+} 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -70,4 +70,12 @@ class User extends Authenticatable
         $this->current_organization_id = $organization->id;
         $this->save();
     }
+
+    // Switch to the first available organization
+    public function switchToAvailableOrganization(): void
+    {
+        $availableOrganization = $this->organizations()->first();
+        $this->current_organization_id = $availableOrganization?->id ?? null;
+        $this->save();
+    }
 }

--- a/app/Services/OrganizationService.php
+++ b/app/Services/OrganizationService.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\Role;
+use App\Models\Organization;
+use App\Models\User;
+
+class OrganizationService
+{
+    /**
+     * Create a new offer from a template.
+     *
+     * @param string $joinToken
+     * @return Organization
+     */
+    public function getOrganizationByJoinToken($joinToken): ?Organization
+    {
+        $organization = null;
+        
+        if ($joinToken) {
+            $organization = Organization::where('join_token', $joinToken)->first();
+        }
+
+        return $organization;
+    }
+    
+    /**
+     * Attach a user to an organization.
+     *
+     * @param User $user
+     * @param Organization $organization
+     */
+    public function attachUserToOrganization(User $user, Organization $organization): void
+    {
+        $organization->users()->attach($user, ['role' => Role::MEMBER]);
+        $user->switchOrganization($organization);
+    }
+} 

--- a/database/migrations/2025_04_16_021535_add_join_token_to_organizations_table.php
+++ b/database/migrations/2025_04_16_021535_add_join_token_to_organizations_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('organizations', function (Blueprint $table) {
+            $table->string('join_token')->nullable()->after('ulid');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('organizations', function (Blueprint $table) {
+            $table->dropColumn('join_token');
+        });
+    }
+};

--- a/database/migrations/2025_04_16_073141_add_role_to_organization_users_table.php
+++ b/database/migrations/2025_04_16_073141_add_role_to_organization_users_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use App\Enums\Role;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('organization_users', function (Blueprint $table) {
+            $table->string('role')->default(Role::MEMBER->value);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('organization_users', function (Blueprint $table) {
+            $table->dropColumn('role');
+        });
+    }
+};

--- a/resources/js/layouts/auth-layout.tsx
+++ b/resources/js/layouts/auth-layout.tsx
@@ -1,6 +1,6 @@
 import AuthLayoutTemplate from '@/layouts/auth/auth-simple-layout';
 
-export default function AuthLayout({ children, title, description, ...props }: { children: React.ReactNode; title: string; description: string }) {
+export default function AuthLayout({ children, title, description, ...props }: { children: React.ReactNode; title?: React.ReactNode; description?: React.ReactNode }) {
     return (
         <AuthLayoutTemplate title={title} description={description} {...props}>
             {children}

--- a/resources/js/pages/auth/join.tsx
+++ b/resources/js/pages/auth/join.tsx
@@ -1,0 +1,83 @@
+import { Head, useForm, usePage } from '@inertiajs/react';
+import { LoaderCircle, AlertCircle, Building2 } from 'lucide-react';
+import { FormEventHandler } from 'react';
+
+import { Button } from '@/components/ui/button';
+import AuthLayout from '@/layouts/auth-layout';
+import { Organization, SharedData } from '@/types';
+import TextLink from '@/components/text-link';
+
+interface JoinPageProps {
+    organization?: Organization;
+}
+
+export default function Join({ organization }: JoinPageProps) {
+    const page = usePage<SharedData>();
+    const { auth } = page.props;
+    const { post, processing } = useForm();
+
+    const submit: FormEventHandler = (e) => {
+        e.preventDefault();
+        post(route('organizations.join'));
+    };
+
+    if (!organization) {
+        return (
+            <AuthLayout 
+                title={
+                    <div className="flex flex-row justify-center items-center gap-4">
+                        <AlertCircle className="h-6 w-6 text-destructive" />
+                        Invalid Invitation
+                    </div>
+                }
+                description=" This invitation link is invalid or has expired. Please contact the organization administrator for a new invitation."
+            >
+                <Head title="Invalid Invitation" />
+                {!auth.user && (
+                    <div className="text-muted-foreground text-center text-sm">
+                        Don't have an account?{' '}
+                        <TextLink href={route('register')}>
+                            Register
+                        </TextLink>
+                        {' '}or{' '}
+                        <TextLink href={route('login')}>
+                            Log in
+                        </TextLink>
+                    </div>
+                )}
+            </AuthLayout>
+        );
+    }
+
+    return (
+        <AuthLayout 
+            title={
+                <div className="flex flex-row justify-center items-center gap-4">
+                    <Building2 className="h-6 w-6 text-primary" />
+                    Join {organization.name}
+                </div>
+            }
+            description="You've been invited to join this organization. Click the button below to join."
+        >
+            <Head title={`Join ${organization.name}`} />
+            
+            <div className="flex flex-col items-center gap-6">
+                <form className="w-full" onSubmit={submit}>
+                    <Button type="submit" className="w-full" disabled={processing}>
+                        {processing && <LoaderCircle className="h-4 w-4 animate-spin mr-2" />}
+                        Join Team
+                    </Button>
+                </form>
+                
+                {!auth.user && (
+                    <div className="text-muted-foreground text-center text-sm">
+                       Already have an account?{' '}
+                        <TextLink href={route('login')}>
+                            Log in
+                        </TextLink>
+                    </div>
+                )}
+            </div>
+        </AuthLayout>
+    );
+} 

--- a/resources/js/pages/auth/login.tsx
+++ b/resources/js/pages/auth/login.tsx
@@ -1,5 +1,5 @@
 import { Head, useForm } from '@inertiajs/react';
-import { LoaderCircle } from 'lucide-react';
+import { Building2, LoaderCircle } from 'lucide-react';
 import { FormEventHandler } from 'react';
 
 import InputError from '@/components/input-error';
@@ -9,6 +9,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import AuthLayout from '@/layouts/auth-layout';
+import { Organization } from '@/types';
 
 type LoginForm = {
     email: string;
@@ -19,9 +20,10 @@ type LoginForm = {
 interface LoginProps {
     status?: string;
     canResetPassword: boolean;
+    organization?: Organization;
 }
 
-export default function Login({ status, canResetPassword }: LoginProps) {
+export default function Login({ status, canResetPassword, organization }: LoginProps) {
     const { data, setData, post, processing, errors, reset } = useForm<Required<LoginForm>>({
         email: '',
         password: '',
@@ -36,7 +38,16 @@ export default function Login({ status, canResetPassword }: LoginProps) {
     };
 
     return (
-        <AuthLayout title="Log in to your account" description="Enter your email and password below to log in">
+        <AuthLayout 
+            title={organization
+                ? <div className="flex flex-row justify-center items-center gap-4">
+                    <Building2 className="h-6 w-6 text-primary" />
+                    Join {organization.name}
+                </div>
+                : "Log in to your account"
+            } 
+            description="Enter your email and password below to log in"
+        >
             <Head title="Log in" />
 
             <form className="flex flex-col gap-6" onSubmit={submit}>
@@ -92,7 +103,7 @@ export default function Login({ status, canResetPassword }: LoginProps) {
 
                     <Button type="submit" className="mt-4 w-full" tabIndex={4} disabled={processing}>
                         {processing && <LoaderCircle className="h-4 w-4 animate-spin" />}
-                        Log in
+                        {organization ? 'Log in and join team' : 'Log in'}
                     </Button>
                 </div>
 

--- a/resources/js/pages/auth/register.tsx
+++ b/resources/js/pages/auth/register.tsx
@@ -1,5 +1,5 @@
 import { Head, useForm } from '@inertiajs/react';
-import { LoaderCircle } from 'lucide-react';
+import { Building2, LoaderCircle } from 'lucide-react';
 import { FormEventHandler } from 'react';
 
 import InputError from '@/components/input-error';
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import AuthLayout from '@/layouts/auth-layout';
+import { Organization } from '@/types';
 
 type RegisterForm = {
     name: string;
@@ -16,7 +17,11 @@ type RegisterForm = {
     password_confirmation: string;
 };
 
-export default function Register() {
+interface RegisterProps {
+    organization?: Organization;
+}
+
+export default function Register({ organization }: RegisterProps) {
     const { data, setData, post, processing, errors, reset } = useForm<Required<RegisterForm>>({
         name: '',
         email: '',
@@ -32,7 +37,16 @@ export default function Register() {
     };
 
     return (
-        <AuthLayout title="Create an account" description="Enter your details below to create your account">
+        <AuthLayout 
+            title={organization
+                ? <div className="flex flex-row justify-center items-center gap-4">
+                    <Building2 className="h-6 w-6 text-primary" />
+                    Join {organization.name}
+                </div>
+                : "Create an account"
+            } 
+            description="Enter your details below to create your account"
+        >
             <Head title="Register" />
             <form className="flex flex-col gap-6" onSubmit={submit}>
                 <div className="grid gap-6">
@@ -103,7 +117,7 @@ export default function Register() {
 
                     <Button type="submit" className="mt-2 w-full" tabIndex={5} disabled={processing}>
                         {processing && <LoaderCircle className="h-4 w-4 animate-spin" />}
-                        Create account
+                        {organization ? 'Create account and join team' : 'Create account'}
                     </Button>
                 </div>
 

--- a/resources/js/pages/organizations/settings/team.tsx
+++ b/resources/js/pages/organizations/settings/team.tsx
@@ -1,32 +1,59 @@
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import SettingsLayout from '@/layouts/settings-layout';
-import { type Organization, type User } from '@/types';
-import { Head } from '@inertiajs/react';
-import { Copy } from 'lucide-react';
+import { SharedData, type Organization, type User } from '@/types';
+import { Head, router, usePage } from '@inertiajs/react';
+import { Copy, Trash2 } from 'lucide-react';
 import { useState } from 'react';
+import { 
+    AlertDialog, 
+    AlertDialogAction, 
+    AlertDialogCancel, 
+    AlertDialogContent, 
+    AlertDialogDescription, 
+    AlertDialogFooter, 
+    AlertDialogHeader, 
+    AlertDialogTitle 
+} from '@/components/ui/alert-dialog';
+import { toast } from 'sonner';
 
 interface Props {
-    organization: Organization & {
-        users: User[];
-    };
+    organization: Organization;
 }
 
 export default function Team({ organization }: Props) {
-    const [inviteEmail, setInviteEmail] = useState('');
-
-    const handleInvite = (e: React.FormEvent) => {
-        e.preventDefault();
-        // TODO: Implement invite functionality
-        setInviteEmail('');
-    };
+    const page = usePage<SharedData>();
+    const { auth } = page.props;
+    const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+    const [userToDelete, setUserToDelete] = useState<User | null>(null);
+    const [isDeleting, setIsDeleting] = useState(false);
 
     const copyInviteLink = () => {
         navigator.clipboard.writeText(organization.invite_link);
-        // toast.success('Invite link copied to clipboard');
+        toast.success('Invite link copied to clipboard');
+    };
+
+    const handleDeleteClick = (user: User) => {
+        setUserToDelete(user);
+        setIsDeleteDialogOpen(true);
+    };
+
+    const handleDeleteConfirm = () => {
+        if (userToDelete) {
+            setIsDeleting(true);
+            
+            router.delete(route('organizations.settings.team.remove', userToDelete.id), {
+                onSuccess: () => {
+                    setIsDeleteDialogOpen(false);
+                    setUserToDelete(null);
+                },
+                onFinish: () => {
+                    setIsDeleting(false);
+                }
+            });
+        }
     };
 
     return (
@@ -37,7 +64,7 @@ export default function Team({ organization }: Props) {
                     <CardHeader>
                         <CardTitle>Team Members</CardTitle>
                         <CardDescription>
-                            Manage your team members and their roles.
+                            Manage your organization's team members and their roles.
                         </CardDescription>
                     </CardHeader>
                     <CardContent>
@@ -47,14 +74,27 @@ export default function Team({ organization }: Props) {
                                     <TableHead>Name</TableHead>
                                     <TableHead>Email</TableHead>
                                     <TableHead>Role</TableHead>
+                                    <TableHead className="w-[100px]">Actions</TableHead>
                                 </TableRow>
                             </TableHeader>
                             <TableBody>
-                                {organization.users.map((user) => (
+                                {organization?.users?.map((user) => (
                                     <TableRow key={user.id}>
                                         <TableCell>{user.name}</TableCell>
                                         <TableCell>{user.email}</TableCell>
-                                        <TableCell>Member</TableCell>
+                                        <TableCell className="capitalize">{user.pivot.role}</TableCell>
+                                        <TableCell>
+                                            {user.id !== auth.user.id && (
+                                                <Button 
+                                                    variant="ghost" 
+                                                    size="icon" 
+                                                    onClick={() => handleDeleteClick(user)}
+                                                    className="text-destructive hover:text-destructive/90"
+                                                >
+                                                    <Trash2 className="h-4 w-4" />
+                                                </Button>
+                                            )}
+                                        </TableCell>
                                     </TableRow>
                                 ))}
                             </TableBody>
@@ -80,31 +120,30 @@ export default function Team({ organization }: Props) {
                         </Button>
                     </CardContent>
                 </Card>
-
-                <Card>
-                    <CardHeader>
-                        <CardTitle>Invite by Email</CardTitle>
-                        <CardDescription>
-                            Send an invitation email to a new team member.
-                        </CardDescription>
-                    </CardHeader>
-                    <CardContent>
-                        <form onSubmit={handleInvite} className="flex items-end gap-4">
-                            <div className="flex-1 space-y-2">
-                                <Label htmlFor="email">Email address</Label>
-                                <Input
-                                    id="email"
-                                    type="email"
-                                    value={inviteEmail}
-                                    onChange={(e) => setInviteEmail(e.target.value)}
-                                    placeholder="colleague@company.com"
-                                />
-                            </div>
-                            <Button type="submit">Send Invite</Button>
-                        </form>
-                    </CardContent>
-                </Card>
             </div>
+
+            {/* Delete confirmation dialog */}
+            <AlertDialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Remove Team Member</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            Are you sure you want to remove {userToDelete?.name} from the organization?
+                            This action cannot be undone.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+                        <AlertDialogAction 
+                            onClick={handleDeleteConfirm}
+                            className="bg-destructive text-white hover:bg-destructive/90"
+                            disabled={isDeleting}
+                        >
+                            {isDeleting ? 'Removing...' : 'Remove'}
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
         </SettingsLayout>
     );
 } 

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -5,6 +5,12 @@ export interface Organization {
     name: string;
     ulid: string;
     invite_link: string;
+    join_token: string;
+    users?: (User & {
+        pivot: {
+            role: string;
+        };
+    })[];
 }
 
 export interface User {

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Auth\NewPasswordController;
 use App\Http\Controllers\Auth\PasswordResetLinkController;
 use App\Http\Controllers\Auth\RegisteredUserController;
 use App\Http\Controllers\Auth\VerifyEmailController;
+use App\Http\Controllers\OrganizationController;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware('guest')->group(function () {
@@ -54,3 +55,10 @@ Route::middleware('auth')->group(function () {
     Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])
         ->name('logout');
 });
+
+// Made the join route public
+Route::get('join/{join_token}', [OrganizationController::class, 'joinPage'])
+    ->name('auth.join');
+
+Route::post('organizations/join', [OrganizationController::class, 'join'])->name('organizations.join');
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,7 +28,6 @@ Route::middleware(['auth', 'verified'])->group(function () {
     // Organization routes
     Route::prefix('organizations')->name('organizations.')->group(function () {
         Route::post('/', [OrganizationController::class, 'store'])->name('store');
-        Route::get('join/{ulid}', [OrganizationController::class, 'join'])->name('join');
         Route::post('switch/{organization}', [OrganizationController::class, 'switch'])->name('switch');
         Route::put('/{organization}', [OrganizationController::class, 'update'])->name('update');
 
@@ -38,6 +37,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
                 Route::get('/', [OrganizationController::class, 'settings'])->name('general');
                 Route::get('/team', [OrganizationController::class, 'team'])->name('team');
                 Route::get('/billing', [OrganizationController::class, 'billing'])->name('billing');
+                Route::delete('/team/{user}', [OrganizationController::class, 'removeTeamMember'])->name('team.remove');
             });
         });
     });

--- a/tests/Feature/OrganizationTest.php
+++ b/tests/Feature/OrganizationTest.php
@@ -1,0 +1,256 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Organization;
+use App\Models\User;
+use App\Enums\Role;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class OrganizationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Organization $organization;
+    private User $owner;
+    private User $member;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Create an organization with an owner
+        $this->owner = User::factory()->create();
+        $this->organization = Organization::factory()->create();
+        $this->organization->users()->attach($this->owner, ['role' => Role::MEMBER->value]);
+        $this->owner->switchOrganization($this->organization);
+
+        // Create a member
+        $this->member = User::factory()->create();
+        $this->organization->users()->attach($this->member, ['role' => Role::MEMBER->value]);
+        $this->member->switchOrganization($this->organization);
+    }
+
+    #[Test]
+    public function owner_can_remove_team_member()
+    {
+        $this->actingAs($this->owner)
+            ->delete(route('organizations.settings.team.remove', [
+                'organization' => $this->organization->id,
+                'user' => $this->member->id,
+            ]))
+            ->assertRedirect()
+            ->assertSessionHas('success');
+
+        $this->assertDatabaseMissing('organization_users', [
+            'organization_id' => $this->organization->id,
+            'user_id' => $this->member->id,
+        ]);
+    }
+
+    #[Test]
+    public function member_can_remove_other_team_members()
+    {
+        $organization = Organization::factory()->create();
+        $otherMember = User::factory()->create([
+            'current_organization_id' => $organization->id,
+        ]);
+        $this->organization->users()->attach($otherMember, ['role' => Role::MEMBER->value]);
+
+        $this->actingAs($this->member)
+            ->delete(route('organizations.settings.team.remove', [
+                'organization' => $this->organization->id,
+                'user' => $otherMember->id,
+            ]))
+            ->assertFound();
+
+        $this->assertDatabaseMissing('organization_users', [
+            'organization_id' => $this->organization->id,
+            'user_id' => $otherMember->id,
+        ]);
+    }
+
+    #[Test]
+    public function user_cannot_remove_themselves_from_organization()
+    {
+        $this->actingAs($this->member)
+            ->delete(route('organizations.settings.team.remove', [
+                'organization' => $this->organization->id,
+                'user' => $this->member->id,
+            ]))
+            ->assertRedirect()
+            ->assertSessionHas('error', 'You cannot remove yourself from the organization.');
+
+        $this->assertDatabaseHas('organization_users', [
+            'organization_id' => $this->organization->id,
+            'user_id' => $this->member->id,
+        ]);
+    }
+
+    #[Test]
+    public function guest_can_view_join_page()
+    {
+        $response = $this->get(route('auth.join', $this->organization->join_token));
+
+        $response->assertStatus(200)
+            ->assertInertia(fn ($assert) => $assert
+                ->component('auth/join')
+                ->has('organization')
+                ->where('organization.id', $this->organization->id)
+                ->where('organization.name', $this->organization->name)
+            );
+    }
+
+    #[Test]
+    public function authenticated_user_can_join_via_join_page()
+    {
+        $organization = Organization::factory()->create();
+        $newUser = User::factory()->create([
+            'current_organization_id' => $organization->id,
+        ]);
+
+        $response = $this->actingAs($newUser)
+            ->post(route('organizations.join'), [
+                'join_token' => $this->organization->join_token,
+            ]);
+
+        $response->assertRedirect(route('dashboard'))
+            ->assertSessionHas('success');
+
+        $this->assertDatabaseHas('organization_users', [
+            'organization_id' => $this->organization->id,
+            'user_id' => $newUser->id,
+            'role' => Role::MEMBER->value,
+        ]);
+    }
+
+    #[Test]
+    public function guest_is_redirected_to_register_when_joining()
+    {
+        $response = $this->post(route('organizations.join'), [
+            'join_token' => $this->organization->join_token,
+        ]);
+
+        $response->assertRedirect(route('register'));
+    }
+
+    #[Test]
+    public function user_can_join_after_registration()
+    {
+        // Store join token in session
+        session(['join_token' => $this->organization->join_token]);
+
+        // Create a new user through registration
+        $userData = [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ];
+
+        $response = $this->post(route('register'), $userData);
+
+        $newUser = User::where('email', 'test@example.com')->first();
+        
+        $this->assertDatabaseHas('organization_users', [
+            'organization_id' => $this->organization->id,
+            'user_id' => $newUser->id,
+            'role' => Role::MEMBER->value,
+        ]);
+
+        $response->assertRedirect(route('dashboard'));
+    }
+
+    #[Test]
+    public function user_can_join_after_login()
+    {
+        // Store join token in session
+        session(['join_token' => $this->organization->join_token]);
+
+        $newUser = User::factory()->create([
+            'password' => bcrypt('password'),
+        ]);
+
+        $response = $this->post(route('login'), [
+            'email' => $newUser->email,
+            'password' => 'password',
+        ]);
+
+        $this->assertDatabaseHas('organization_users', [
+            'organization_id' => $this->organization->id,
+            'user_id' => $newUser->id,
+            'role' => Role::MEMBER->value,
+        ]);
+
+        $response->assertRedirect(route('dashboard'));
+    }
+
+    #[Test]
+    public function cannot_join_with_invalid_token()
+    {
+        $organization = Organization::factory()->create();
+        $newUser = User::factory()->create([
+            'current_organization_id' => $organization->id,
+        ]);
+
+        $response = $this->actingAs($newUser)
+            ->post(route('organizations.join'), [
+                'join_token' => 'invalid-token',
+            ]);
+
+        $response->assertRedirect(route('home'))
+            ->assertSessionHas('error', 'Invalid join link.');
+
+        $this->assertDatabaseMissing('organization_users', [
+            'organization_id' => $this->organization->id,
+            'user_id' => $newUser->id,
+        ]);
+    }
+
+    #[Test]
+    public function user_cannot_join_organization_twice()
+    {
+        $response = $this->actingAs($this->member)
+            ->post(route('organizations.join'), [
+                'join_token' => $this->organization->join_token,
+            ]);
+
+        $response->assertRedirect()
+            ->assertSessionHas('error', 'You are already a member of this organization.');
+
+        $this->assertDatabaseCount('organization_users', 2); // Only owner and original member
+    }
+
+    #[Test]
+    public function user_current_organization_is_switched_when_removed_from_current_org()
+    {
+        // Create another organization for the member to be part of
+        $otherOrganization = Organization::factory()->create();
+        $this->member->organizations()->attach($otherOrganization, ['role' => Role::MEMBER->value]);
+        
+        // Verify member's current organization is the one we're about to remove them from
+        $this->assertEquals($this->organization->id, $this->member->current_organization_id);
+
+        $this->actingAs($this->owner)
+            ->delete(route('organizations.settings.team.remove', [
+                'organization' => $this->organization->id,
+                'user' => $this->member->id,
+            ]))
+            ->assertRedirect()
+            ->assertSessionHas('success');
+
+        // Refresh the member model to get updated data
+        $this->member->refresh();
+
+        // Assert that the member's current organization has been switched to the other organization
+        $this->assertEquals($otherOrganization->id, $this->member->current_organization_id);
+        
+        // Verify they were removed from the original organization
+        $this->assertDatabaseMissing('organization_users', [
+            'organization_id' => $this->organization->id,
+            'user_id' => $this->member->id,
+        ]);
+    }
+} 


### PR DESCRIPTION
Features:

- Removed "Invite by Email" from UI
- Generate a `join_token` for each Organization to be used for Invite link
- Create a landing page for Joining a Team (Supports existing and new users)
- Allow Team member deletion (except for the current user logged in)
- Implement a simple `role` field on `organization_user` pivot model

Additional Features:
- Support on edge case: If a User was removed from its main Organization, it switches to the next available Organization.